### PR TITLE
fix(box): Button role and keydown events

### DIFF
--- a/example/src/examples/Box.vue
+++ b/example/src/examples/Box.vue
@@ -10,7 +10,12 @@
     <f-box v-else-if="activeExample === 'bordered'" as="section" bordered>
       <h1>I am some content</h1>
     </f-box>
-    <f-box v-else-if="activeExample === 'clickable'" info clickable>
+    <f-box
+      v-else-if="activeExample === 'clickable'"
+      info
+      clickable
+      @click="clickAction"
+    >
       <h1>I am some content</h1>
     </f-box>
 
@@ -95,6 +100,7 @@ const exampleToggles = [
   { label: 'Clickable', value: 'clickable' }
 ]
 const activeExample = ref('bleed')
+const clickAction = () => alert(`You clicked me!`)
 
 const token =
 `<f-box info>

--- a/packages/box/f-box.js
+++ b/packages/box/f-box.js
@@ -14,7 +14,7 @@ export default {
     neutral: Boolean,
     bordered: Boolean
   },
-  setup: (props, { slots }) => () => h(props.as, {
+  setup: (props, { slots, attrs }) => () => h(props.as, {
     class: {
       [c.box]: true,
       [c.bleed]: props.bleed,
@@ -26,6 +26,19 @@ export default {
       'border-2 border-bluegray-300': props.bordered
     },
     tabindex: props.clickable ? 0 : undefined,
-    role: props.clickable ? 'button' : undefined
-  }, slots.default())
+    onKeydown: props.clickable ? (event) => {
+      // Manually mapping Enter and Space keydown events to the click event (if there is one).
+      // The browser doesn't do this automatically unless the element is a button or an a-element.
+      // The Box element can't be a button or link in case someone puts an interactive element inside the box, which would result in invalid HTML and severe a11y issues.
+      if (typeof attrs.onClick === 'function' && (event.keyCode === 13 || event.keyCode === 32)) {
+        attrs.onClick(event)
+      }
+    } : undefined
+  }, props.clickable ? [
+    slots.default(),
+    h('span', {
+      role: 'button',
+      'aria-label': 'Les mer'
+    })
+  ] : slots.default())
 }


### PR DESCRIPTION
1. Move the button role from the Box element to a separate child element to prevent a11y issues when children of the Box are block elements, interactive elements, or some other type of descendants that would be invalid inside a button.
2. Manually map Enter and Space key events to the click event (if any). The browser doesn't do this mapping automatically unless the element is a button or a link, which is not tolerable in this case.