### PR TITLE
build: add githubs actions deploy script for gh pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: |
+          yarn
+      - name: Build Docs
+        run: |
+          cd example && yarn site
+      - name: Deploy
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: example/dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Making an attempt here to build the docs for gh pages so we can get it over to open source.finn.no.
I'm not 100% this is correct yet but no way to test it without trying. Also, I don't have access to settings for this repo to set anything up.